### PR TITLE
Removed the appId, appKey to avoid seeing comments of others

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,8 +55,8 @@ search:
 ## 若关闭valine 设置enable为false∂
 valine:
   enable: true
-  appId: NOsswOncKgc8HOxqo9oxIWlX-gzGzoHsz
-  appKey: z1FihjWEbS8uIfUQdmCtK7zz
+  appId: 
+  appKey: 
 
 # visitors count
 counter:


### PR DESCRIPTION
This will allow the user who installs the plugin to see the comments from original posts. Its better to create your own appid and appkey by following the guidelines mentioned by valine